### PR TITLE
chore(devscript): Update build_vtk.sh

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,13 +46,13 @@ Optionally, you can develop with bleeding edge VTK by following these steps
 .. code-block:: console
 
     # Compile VTK for wasm32 architecture using emscripten. Build artifacts can be found in dev/vtk/build/wasm
-    docker run --rm -it -u$(id -u):$(id -g) -v$PWD:/work dockcross/web-wasm:20230831-0ac0f7a ./utils/build_vtk.sh wasm32
+    docker run --rm -it -v$PWD:/work kitware/vtk:ci-fedora39-20240731 /bin/bash -c "cd /work && ./utils/build_vtk.sh -u https://gitlab.kitware.com/vtk/vtk.git -b master -t wasm32 -p RelWithDebInfo"
 
     # Compile VTK with python wrappings using system C++ compiler. Build artifacts can be found in dev/vtk/build/py
-    ./utils/build_vtk.sh py
+    ./utils/build_vtk.sh -u https://gitlab.kitware.com/vtk/vtk.git -b master -t py -p RelWithDebInfo
 
     # Set environment variables
-    source ./utils/dev_environment.sh
+    source ./utils/dev_environment.sh -b master -p RelWithDebInfo
 
 Running examples
 ----------------------------------------

--- a/utils/dev_environment.sh
+++ b/utils/dev_environment.sh
@@ -1,3 +1,23 @@
-readonly py_version=$(python -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
-export PYTHONPATH="$PWD/dev/vtk/build/py/lib/python$py_version/site-packages"
-export VTK_WASM_DIR=$PWD/dev/vtk/build/wasm/bin
+#!/bin/bash
+
+while getopts b:p: flag
+do
+    case "${flag}" in
+        b) vtk_branch=${OPTARG};;
+        p) build_type=${OPTARG};;
+        *)
+            echo "Unrecognized argument"
+            exit 1
+            ;;
+    esac
+done
+
+readonly vtk_branch
+readonly build_target
+readonly build_type
+readonly git_clone_dir="$(pwd)/dev/vtk-$vtk_branch"
+readonly build_dir="build/$build_type"
+
+readonly py_version=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+export PYTHONPATH="$git_clone_dir/$build_dir/py/lib/python$py_version/site-packages"
+export VTK_WASM_DIR="$git_clone_dir/$build_dir/wasm32/bin"


### PR DESCRIPTION
- Uses newer VTK CI image for wasm32 builds
- Adds CLI arguments to customize VTK git url, branch, build type and build target.
- Update README.rst with new instructions.