### PR TITLE
fix(interaction): await on scene manager render

### DIFF
--- a/vue-components/src/components/VtkLocal.js
+++ b/vue-components/src/components/VtkLocal.js
@@ -153,11 +153,11 @@ export default {
 
     // Resize -----------------------------------------------------------------
 
-    function resize() {
+    async function resize() {
       const { width, height } = container.value.getBoundingClientRect();
       const w = Math.floor(width * window.devicePixelRatio + 0.5);
       const h = Math.floor(height * window.devicePixelRatio + 0.5);
-      wasmManager.setSize(props.renderWindow, w, h);
+      await wasmManager.setSize(props.renderWindow, w, h);
     }
     let resizeObserver = new ResizeObserver(resize);
 

--- a/vue-components/src/remote.js
+++ b/vue-components/src/remote.js
@@ -297,7 +297,7 @@ export class RemoteSession {
           );
         }
 
-        this.sceneManager.render(vtkId);
+        await this.sceneManager.render(vtkId);
         // TODO outside:
         // - freeMemory: to keep memory in check
       } catch (e) {
@@ -415,7 +415,7 @@ export class RemoteSession {
    * @param {int} width
    * @param {int} height
    */
-  setSize(renderWindowId, width, height) {
+  async setSize(renderWindowId, width, height) {
     this.renderWindowSizes[renderWindowId] = [width, height];
     const canvasSelector = this.getCanvasSelector(renderWindowId);
     const canvas = document.querySelector(canvasSelector);
@@ -424,7 +424,7 @@ export class RemoteSession {
       canvas.height = height;
 
       this.sceneManager.setSize(renderWindowId, width, height);
-      this.sceneManager.render(renderWindowId);
+      await this.sceneManager.render(renderWindowId);
     }
   }
 }


### PR DESCRIPTION
- `vtkRemoteSession::Render` returns promise in async mode.
- when not awaited, the `startEventLoop` got called before the interactor->Enabled was set to true, therefore `startEventLoop` became a no-op
- also use await on other methods which call `vtkRemoteSession::Render`.