### PR TITLE
fix(examples): bump vtk-wasm and vtk for picker examples

### DIFF
--- a/examples/vtk/actor_picker.py
+++ b/examples/vtk/actor_picker.py
@@ -5,8 +5,8 @@
 #
 # dependencies = [
 #   "trame>=3.9",
-#   "trame-vtklocal<0.12",
-#   "vtk==9.4.20250510.dev0",
+#   "trame-vtklocal>0.16",
+#   "vtk==9.5.20250712.dev0",
 # ]
 #
 # [[tool.uv.index]]

--- a/examples/vtk/actor_picker2.py
+++ b/examples/vtk/actor_picker2.py
@@ -5,8 +5,8 @@
 #
 # dependencies = [
 #   "trame>=3.9",
-#   "trame-vtklocal>=0.11",
-#   "vtk==9.4.20250510.dev0",
+#   "trame-vtklocal>=0.16",
+#   "vtk==9.6.0",
 # ]
 #
 # [[tool.uv.index]]


### PR DESCRIPTION
The `actor_picker` and `actor_picker2` scripts were not working with pinned versions. Bumping versions resolves the issues.