### PR TITLE
feat: add the ability to pass additional data arguments `LocalView.update()`

### DIFF
--- a/src/trame_vtklocal/widgets/vtklocal.py
+++ b/src/trame_vtklocal/widgets/vtklocal.py
@@ -5,6 +5,7 @@ import json
 import warnings
 import zipfile
 from pathlib import Path
+from typing import Any
 
 from trame_client.widgets.core import AbstractElement
 from trame_common.exec.throttle import Throttle
@@ -213,13 +214,13 @@ class LocalView(HtmlElement):
         """
         return self._update_throttle
 
-    def update(self, push_camera=False):
+    def update(self, push_camera=False, **kwargs: Any):
         """Sync view by pushing updates to client"""
         self.api.update(
             push_camera=push_camera,
             obj_to_update=[self._render_window, *self.__registered_obj],
         )
-        self.server.js_call(self.__ref, "update")
+        self.server.js_call(self.__ref, "update", kwargs)
 
     def register_vtk_object(self, vtk_instance):
         """Register external element (i.e. widget) into the scene so it can be managed and return its wasm_id"""

--- a/vue-components/src/components/VtkLocal.js
+++ b/vue-components/src/components/VtkLocal.js
@@ -530,7 +530,14 @@ export default {
 
     return {
       container,
-      update,
+      async update(){
+        // Server.js_call("update") could potentially send a
+        // payload, so wrap the inner update() function in order
+        // to control the method signature for the Trame callback.
+        // This way, payload arguments to the Trame callback do not
+        // interfere with the internal "bindCanvas" argument.
+        await update(false);
+      },
       resetCamera,
       render,
       evalStateExtract,


### PR DESCRIPTION
Occasionally we need to send additional arbitrary data to the frontend when we make a call to `LocalView.update()` on the server. This PR adds the ability to pass arguments to the call to `Server.js_call()` that `LocalView.update()` makes internally.