### PR TITLE
chore(example): call getEventPosition on interactor instead of  .eventPosition

### DIFF
--- a/examples/vtk/actor_picker2.py
+++ b/examples/vtk/actor_picker2.py
@@ -182,7 +182,7 @@ function setupJSPicking(refName, interactorId, pickerId, renderWindowId, rendere
     const prop = getVtkObject(propId);
 
     interactor.observe("MouseMoveEvent", async () => {
-          const pos = interactor.eventPosition;
+          const pos = await interactor.getEventPosition();
           await pick([pos[0], pos[1], 0], picker, renderWindow, renderer, prop);
     });
 }""")


### PR DESCRIPTION
closes https://github.com/Kitware/trame-vtklocal/issues/78