### PR TITLE
Handle vtk >= 9.7.20260716 wasm package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pytest-playwright",
     "trame-client[test]",
     # Dev wheel from wheels.vtk.org (see [tool.uv] below)
-    "vtk==9.7.20260712.dev0",
+    "vtk==9.7.20260726.dev0",
 ]
 
 # Resolve the pinned vtk dev build from the VTK nightly wheel index instead of

--- a/src/trame_vtklocal/module/wasm.py
+++ b/src/trame_vtklocal/module/wasm.py
@@ -110,29 +110,31 @@ def register_wasm(serve_path, wasm_bits="wasm32", **kwargs):
         wasm_url = kwargs.get("wasm_url", wasm_url)
 
         # if the required wasm files do not exist, we need to download them
-        # Versions before 9.5.20250531 use different WASM file naming conventions.
-        # this cutoff distinguishes between old and new formats.
+        # The archive contents changed over time; these cutoffs distinguish the formats:
+        # - before 9.5.20250531: vtkWasmSceneManager.{mjs,wasm}
+        # - before 9.7.20260716: separate webgl ({base}WebAssembly.{mjs,wasm}) and
+        #   webgpu ({base}WebAssemblyAsync.{mjs,wasm}) builds
+        # - from 9.7.20260716: single {base}WebAssembly.{mjs,wasm} build with both
+        #   webgl and webgpu support
         if parse(version) < parse("9.5.20250531"):
-            # For older versions, the wasm files are named differently.
-            if (
-                not dest_directory.joinpath("vtkWasmSceneManager.mjs").exists()
-                or not dest_directory.joinpath("vtkWasmSceneManager.wasm").exists()
-            ):
-                run_async(setup_wasm_directory(dest_directory, wasm_url))
+            required_files = [
+                "vtkWasmSceneManager.mjs",
+                "vtkWasmSceneManager.wasm",
+            ]
+        elif parse(version) < parse("9.7.20260716"):
+            required_files = [
+                f"{wasm_base_name}WebAssembly.mjs",
+                f"{wasm_base_name}WebAssembly.wasm",
+                f"{wasm_base_name}WebAssemblyAsync.mjs",
+                f"{wasm_base_name}WebAssemblyAsync.wasm",
+            ]
         else:
-            if (
-                not dest_directory.joinpath(f"{wasm_base_name}WebAssembly.mjs").exists()
-                or not dest_directory.joinpath(
-                    f"{wasm_base_name}WebAssembly.wasm"
-                ).exists()
-                or not dest_directory.joinpath(
-                    f"{wasm_base_name}WebAssemblyAsync.mjs"
-                ).exists()
-                or not dest_directory.joinpath(
-                    f"{wasm_base_name}WebAssemblyAsync.wasm"
-                ).exists()
-            ):
-                run_async(setup_wasm_directory(dest_directory, wasm_url))
+            required_files = [
+                f"{wasm_base_name}WebAssembly.mjs",
+                f"{wasm_base_name}WebAssembly.wasm",
+            ]
+        if any(not dest_directory.joinpath(f).exists() for f in required_files):
+            run_async(setup_wasm_directory(dest_directory, wasm_url))
 
     return dict(
         state={

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vue-trame_vtklocal",
       "version": "0.0.0",
       "dependencies": {
-        "@kitware/vtk-wasm": "^2.1.6"
+        "@kitware/vtk-wasm": "^2.1.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -1362,9 +1362,9 @@
       }
     },
     "node_modules/@kitware/vtk-wasm": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk-wasm/-/vtk-wasm-2.1.6.tgz",
-      "integrity": "sha512-Y0elSl2j7o8qcdnP09v7PNPVLmvR9pe+kQV/jy6MqDAGQJ+D9PJOdrlRrbHzP6aQIK4zfrQgS4mHOCpPt9AgDw==",
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk-wasm/-/vtk-wasm-2.1.8.tgz",
+      "integrity": "sha512-knvGPnHyQxSNdMWOJvTKov4hwrrmebXVkN5YFfshPRdCvDoG+bhTVupGv9RXcJDRdLD8wdoMNE4hYEiGG0LsDw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -14,7 +14,7 @@
     "vue": "^2.7.0 || >=3.0.0"
   },
   "dependencies": {
-    "@kitware/vtk-wasm": "^2.1.6"
+    "@kitware/vtk-wasm": "^2.1.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",


### PR DESCRIPTION
CI will need https://github.com/Kitware/vtk-wasm/pull/57 merged and new release from vtk-wasm. Right now, CI shows:

```
JS Error => Error: Could not locate the WebAssembly glue module for 'vtkWebAssemblyAsync.mjs' under "__trame_vtklocal_1.0.2/wasm32/9.7.20260726".
The file was missing, returned a non-OK response, or the server replied with an HTML document.
```

Updates dev dependency to vtk==9.7.20260726 which is the latest at the time of PR creation.