### PR TITLE
feat(deps): bump vtk-wasm to 3.0

### DIFF
--- a/examples/vtk/actor_picker2.py
+++ b/examples/vtk/actor_picker2.py
@@ -181,7 +181,7 @@ function setupJSPicking(refName, interactorId, pickerId, renderWindowId, rendere
     const renderWindow = getVtkObject(renderWindowId);
     const prop = getVtkObject(propId);
 
-    interactor.observe("MouseMoveEvent", async () => {
+    interactor.$observe("MouseMoveEvent", async () => {
           const pos = await interactor.getEventPosition();
           await pick([pos[0], pos[1], 0], picker, renderWindow, renderer, prop);
     });

--- a/tests/test_cone.py
+++ b/tests/test_cone.py
@@ -92,7 +92,7 @@ async def test_cone(ConeApp, utils, config):
         # client-side serialize that currently corrupts the WebGPU render window
         # (VTK webgpu bug; harmless on webgl), so keep it after every screenshot.
         result = await page.evaluate(
-            "window.trame.refs.cone_view.getVtkObject(1).state.className"
+            "window.trame.refs.cone_view.getVtkObject(1).$state.className"
         )
         assert result == EXPECTED_WINDOW_CLASSNAMES[wasm_rendering]
 

--- a/vue-components/package-lock.json
+++ b/vue-components/package-lock.json
@@ -8,7 +8,7 @@
       "name": "vue-trame_vtklocal",
       "version": "0.0.0",
       "dependencies": {
-        "@kitware/vtk-wasm": "^2.2.0"
+        "@kitware/vtk-wasm": "^3.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -1325,9 +1325,9 @@
       }
     },
     "node_modules/@kitware/vtk-wasm": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@kitware/vtk-wasm/-/vtk-wasm-2.2.0.tgz",
-      "integrity": "sha512-v1P/3KzsDMM20j0mMTCA4wxEFEJQxs5+rTotDiL10GWwjISfAIVzOeCLebbxqYYF6yQpn13Bo5WcMI+kadmmZg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@kitware/vtk-wasm/-/vtk-wasm-3.0.0.tgz",
+      "integrity": "sha512-gkxgn0rzWFa/ELVCFWYHeGuGYHNGndlDPx372jF8MvC59VsKOsdSBHAiQdTE5dxZIfLSYp+8ftUBxFPGs4zt/A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@codemirror/lang-html": "^6.4.11",
@@ -1336,6 +1336,12 @@
         "codemirror": "^6.0.2",
         "js-untar": "^2.0.0",
         "jszip": "3.10.1"
+      },
+      "bin": {
+        "vtk-wasm": "bin/vtk-wasm.mjs"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@lezer/common": {

--- a/vue-components/package.json
+++ b/vue-components/package.json
@@ -14,7 +14,7 @@
     "vue": "^2.7.0 || >=3.0.0"
   },
   "dependencies": {
-    "@kitware/vtk-wasm": "^2.2.0"
+    "@kitware/vtk-wasm": "^3.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",


### PR DESCRIPTION
vtk-wasm v3.0 adds typescript definitions for VTK classes. In order to avoid conflicts with C++ properties with same name as those of a proxy, the proxy returned by `getVtkObject(id)` was amended like:

| old | new |
| -- | -- |
| id | $id |
| obj |$obj |
| observe() | $observe() |
| set() | $set() |
| toJSON() | toJSON() |
| toString() | toString() |
| unObserve() | $unObserve |
| unObserveAll() | $unObserveAll |
| userData | $userData |

For this reason, tests and examples which use these, were renamed. If you use `getVtkObject()` and use any old name in Python (inline JS) or through custom JavaScript, you will need to update the code. See
https://kitware.github.io/vtk-wasm/api/@kitware/vtk-wasm/interfaces/VtkObjectProxyBase.html for the exact API.